### PR TITLE
Add missing help texts

### DIFF
--- a/lancet/autocomplete/zsh.sh
+++ b/lancet/autocomplete/zsh.sh
@@ -1,7 +1,5 @@
 #compdef lancet
 
-local expl
-
 _lancet_commands() {
     local -a commands
     local -a opts

--- a/lancet/base.py
+++ b/lancet/base.py
@@ -36,7 +36,7 @@ class WarnIntegrationHelper(NullIntegrationHelper):
             click.secho('  This basically means to add the following snippet')
             click.secho('  to your shell initialization file:')
             click.secho('')
-            click.secho('    lancet --setup-helper | source /dev/stdin')
+            click.secho('    lancet _setup_helper | source /dev/stdin')
             click.secho('')
             click.secho('  See {} for addtional details.'.format(
                 click.style('https://lancet.rtd.org', fg='green')))

--- a/lancet/commands/configuration.py
+++ b/lancet/commands/configuration.py
@@ -58,7 +58,7 @@ def setup(ctx, force):
 
 @click.command()
 @click.option('-f', '--force/--no-force', default=False,
-              help=('Init even if .lancet already exists.'))
+              help='Init even if .lancet already exists.')
 @click.pass_context
 def init(ctx, force):
     """Wizard to create a project-level configuration file."""

--- a/lancet/commands/configuration.py
+++ b/lancet/commands/configuration.py
@@ -57,7 +57,8 @@ def setup(ctx, force):
 
 
 @click.command()
-@click.option('-f', '--force/--no-force', default=False)
+@click.option('-f', '--force/--no-force', default=False,
+              help=('Init even if .lancet already exists.'))
 @click.pass_context
 def init(ctx, force):
     """Wizard to create a project-level configuration file."""

--- a/lancet/commands/repository.py
+++ b/lancet/commands/repository.py
@@ -8,11 +8,12 @@ from ..helpers import get_issue, get_transition, set_issue_status, get_branch
 
 
 @click.command()
-@click.option('--base', '-b', 'base_branch', help="Branch to make pull request to")
+@click.option('--base', '-b', 'base_branch', 
+              help='Branch to make pull request to.')
 @click.option('-s', '--stop-timer/--no-stop-timer', default=False,
               help='Stops the Harvest timer after creating the pull request.')
 @click.option('-o', '--open-pr/--no-open-pr', default=False,
-              help="Opens the link with the pull request.")
+              help='Opens the link with the pull request.')
 @click.pass_context
 def pull_request(ctx, base_branch, open_pr, stop_timer):
     """Create a new pull request for this issue."""

--- a/lancet/commands/repository.py
+++ b/lancet/commands/repository.py
@@ -8,10 +8,11 @@ from ..helpers import get_issue, get_transition, set_issue_status, get_branch
 
 
 @click.command()
-@click.option('--base', '-b', 'base_branch')
+@click.option('--base', '-b', 'base_branch', help="Branch to make pull request to")
 @click.option('-s', '--stop-timer/--no-stop-timer', default=False,
-              help='Stop the Harvest timer after creating the pull request.')
-@click.option('-o', '--open-pr/--no-open-pr', default=False)
+              help='Stops the Harvest timer after creating the pull request.')
+@click.option('-o', '--open-pr/--no-open-pr', default=False,
+              help="Opens the link with the pull request.")
 @click.pass_context
 def pull_request(ctx, base_branch, open_pr, stop_timer):
     """Create a new pull request for this issue."""

--- a/lancet/commands/workflow.py
+++ b/lancet/commands/workflow.py
@@ -58,7 +58,8 @@ def _project_dirs(lancet):
 
 
 @click.command()
-@click.option('--base', '-b', 'base_branch')
+@click.option('--base', '-b', 'base_branch',
+              help="Base branch to branch off from")
 @click.argument('issue')
 @click.pass_context
 def workon(ctx, issue, base_branch):

--- a/lancet/commands/workflow.py
+++ b/lancet/commands/workflow.py
@@ -113,7 +113,8 @@ def time(lancet, issue):
     Start an Harvest timer for the given issue.
 
     This command takes care of linking the timer with the issue tracker page
-    for the given issue.
+    for the given issue. If the issue is not passed to command it's taken 
+    from currently active branch.
     """
     issue = get_issue(lancet, issue)
 

--- a/lancet/commands/workflow.py
+++ b/lancet/commands/workflow.py
@@ -59,7 +59,7 @@ def _project_dirs(lancet):
 
 @click.command()
 @click.option('--base', '-b', 'base_branch',
-              help="Base branch to branch off from")
+              help='Base branch to branch off from.')
 @click.argument('issue')
 @click.pass_context
 def workon(ctx, issue, base_branch):


### PR DESCRIPTION
this is a wip PR to add all the help texts so autocompletion could just use `lancet _arguments command` for everything
@GaretJax do you want me to put the zsh completion file somewhere in the project as well or should I still keep it [here](https://github.com/vxsx/dotfiles/blob/master/zsh/lancet.zsh)?